### PR TITLE
Various improvements

### DIFF
--- a/cgbind/build.py
+++ b/cgbind/build.py
@@ -54,6 +54,8 @@ def get_kfitted_coords_and_cost(linker, template_x_coords, coords_to_fit, return
     :param return_cost: (bool) return just the cost function, which is the sum of squares of ∆dists
     :return: (np.ndarray) n_atoms x 3
     """
+    assert len(template_x_coords) == len(coords_to_fit)
+
     # Construct the P matrix in the Kabsch algorithm
     p_mat = deepcopy(coords_to_fit)
     p_centroid = np.average(p_mat, axis=0)

--- a/cgbind/cage.py
+++ b/cgbind/cage.py
@@ -287,7 +287,10 @@ class Cage(BaseStruct):
             logger.error('Linker was not reasonable')
             return
 
-        self.name = 'cage_' + linker.name
+        if self.name == 'cage':
+            # Only override the default name
+            self.name = 'cage_' + linker.name
+
         self.arch = linker.arch
         self.linkers = [linker for _ in range(linker.arch.n_linkers)]
         self.cage_template = linker.cage_template
@@ -306,7 +309,10 @@ class Cage(BaseStruct):
             logger.error('Linkers had different architectures, not building a cage')
             return
 
-        self.name = 'cage_' + '_'.join([linker.name for linker in linkers])
+        if self.name == 'cage':
+            # Only override the default name
+            self.name = 'cage_' + '_'.join([linker.name for linker in linkers])
+
         self.arch = linkers[0].arch
         self.linkers = linkers
         self.cage_template = linkers[0].cage_template

--- a/cgbind/exceptions.py
+++ b/cgbind/exceptions.py
@@ -10,7 +10,7 @@ class NoXYZs(Exception):
 
 class CgbindCritical(Exception):
     """Non recoverable error"""
-    def __init__(self, message):
+    def __init__(self, message=''):
         super().__init__(message)
 
 

--- a/cgbind/input_output.py
+++ b/cgbind/input_output.py
@@ -201,13 +201,13 @@ def mol2file_to_atoms(filename):
         if len(atom.label) == 1:
             continue
 
-        # e.g. Pd1 or C58
+        # e.g. P1 or C58
         elif atom.label[0].isalpha() and not atom.label[1].isalpha():
             atom.label = atom.label[0]
 
         # e.g. Pd10
         elif atom.label[0].isalpha() and atom.label[1].isalpha():
-            atom.label = atom.label[:2]
+            atom.label = atom.label[:2].title()
 
         else:
             logger.error('Unrecognised atom type')

--- a/cgbind/templates.py
+++ b/cgbind/templates.py
@@ -95,6 +95,7 @@ class Linker:
         :param atoms: (list(list))
         :param x_atoms: (list(int)) Donor atom ids in the xyzs
         """
+        logger.info('Generating a template linker...')
         self.atoms = atoms                                      #: (list(list))
         self.x_atoms = x_atoms                                  #: (list(int)) List of donor atoms in the linker
         self.coords = np.array([atom.coord for atom in atoms])  #: (list(np.ndarray)) Linker coordinates
@@ -103,6 +104,7 @@ class Linker:
 
         self.x_motifs = find_x_motifs(self)                    #: (list(Xmotif objects)
         self.x_motifs = get_maximally_connected_x_motifs(self.x_motifs, x_atoms=x_atoms)
+
         check_x_motifs(linker_template=self)            # check that the x_motifs are the same length
 
 
@@ -162,6 +164,7 @@ class Template:
                         break
 
             linkers.append(Linker(atoms=atoms, x_atoms=linker_x_atoms))
+            logger.info(f'Linker has {len(linker_x_atoms)} donor atoms')
 
         logger.info(f'Found {len(linkers_atoms)} linkers each with {len(linker_x_atoms)} donor atoms')
         return linkers
@@ -273,6 +276,7 @@ class Template:
 
         self.metals = self._find_metals()
         self.n_metals = len(self.metals)
+        assert self.n_metals > 0
         logger.info(f'Found {self.n_metals} metals')
 
         self.bonds = get_bond_list_from_atoms(self.atoms)

--- a/examples/ex6_cages_from_building_blocks.py
+++ b/examples/ex6_cages_from_building_blocks.py
@@ -30,7 +30,6 @@ top_link_names_smiles = {'alkyne': '.C%99#C%98.'}
 
 centre_names_smiles = {'2-6-pyridine'         : 'C1%98=NC%97=CC=C1',
                        'carbonate'            : 'O=C(O%98)O%97',
-                       '1-8-anthracene'       : 'C1%98=CC=CC2=C1C=C3C(C=CC=C3%97)=C2',
                        '1-3-phenyl'           : 'C1%98=CC=CC%97=C1',
                        '1-3-phenyl-2-methyl'  : 'C1%98=CC=CC%97=C1C',
                        'methylene'            : 'C%98%97'}


### PR DESCRIPTION
Fixed cage names being overridden
Added default cgbindcritical exception message
Fixed .mol2 files allowing both CO and Co atom labels for cobalt (and other metals)
Only use multiprocessing if there are more than 1 core requested, so child processes are not executed
Use NetworkX to check for x-motif connectivity 